### PR TITLE
Change sendMany call to receive generic JSONObject 

### DIFF
--- a/bitgo-java-api/build.gradle
+++ b/bitgo-java-api/build.gradle
@@ -2,7 +2,7 @@ apply plugin:'java'
 apply plugin:'idea'
 
 group = 'com.bitso'
-version='0.0.8'
+version='0.0.9'
 
 repositories {
     mavenCentral()

--- a/bitgo-java-api/build.gradle
+++ b/bitgo-java-api/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.2'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.2'
     compile 'org.slf4j:slf4j-api:1.7.25',
-            'com.fasterxml.jackson.core:jackson-databind:2.9.7',
-            'org.json:json:20190722'
+            'com.fasterxml.jackson.core:jackson-databind:2.9.7'
     testCompile 'junit:junit:4.12'
 }

--- a/bitgo-java-api/build.gradle
+++ b/bitgo-java-api/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.2'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.2'
     compile 'org.slf4j:slf4j-api:1.7.25',
-            'com.fasterxml.jackson.core:jackson-databind:2.9.7'
+            'com.fasterxml.jackson.core:jackson-databind:2.9.7',
+            'org.json:json:20190722'
     testCompile 'junit:junit:4.12'
 }

--- a/bitgo-java-api/src/main/java/com/bitso/bitgo/v2/BitGoClient.java
+++ b/bitgo-java-api/src/main/java/com/bitso/bitgo/v2/BitGoClient.java
@@ -5,6 +5,7 @@ import com.bitso.bitgo.v2.entity.Wallet;
 import com.bitso.bitgo.v2.entity.WalletTransferResponse;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -37,24 +38,26 @@ public interface BitGoClient {
     Optional<Wallet> getWalletByAddress(String coin, String waddress) throws IOException;
 
     /**
-     * Invokes the sendmany method see https://www.bitgo.com/api/v2/?shell#send-transaction-to-many
-     * Required parameters are:
-     * coin                        tbtc for test bitcoin, see full list at https://www.bitgo.com/api/v2/#coin-digital-currency-support
-     * walletId                    The ID of the source wallet.
-     * walletPass                  The wallet passphrase.
-     * recipients                  A map with the recipients' addresses as keys and the corresponding
-     *                                    amounts as values. Amounts are in satoshis
-     * sequenceId                  A unique identifier for this transaction (optional).
      *
-     * Optional parameters are:
-     * message                     Notes about the transaction (optional).
+     * @param coin                  tbtc for test bitcoin, see full list at https://www.bitgo.com/api/v2/#coin-digital-currency-support
+     * @param walletId              The ID of the source wallet.
+     * @param walletPass            The wallet passphrase.
+     * @param recipients            A map with the recipients' addresses as keys and the corresponding
+     *                              amounts as values. Amounts are in satoshis
+     * @param sequenceId            A unique identifier for this transaction (optional).
+     * @param optionalParameters    A map with optional extra parameters.
+     * Some of the known optional parameters are:
+     * message                     Notes about the transaction.
      * fee                         Fee (in satoshis), leave null for autodetect. Do not specify unless you are sure it is sufficient.
      * feeTxConfirmTarget          Calculate fees per kilobyte, targeting transaction confirmation in this number of blocks. Default: 2, Minimum: 2, Maximum: 20
      * minConfirms                 only choose unspent inputs with a certain number of confirmations. We recommend setting this to 1 and using enforceMinConfirmsForChange
      * enforceMinConfirmsForChange Defaults to false. When constructing a transaction, minConfirms will only be enforced for unspents not originating from the wallet
      * @return A SendCoinsResponse, or empty if there was a problem (although more likely in case of a problem it will throw).
+     * @throws IOException
      */
-    Optional<SendCoinsResponse> sendMany(Map<String, Object> parameters) throws IOException;
+    Optional<SendCoinsResponse> sendMany(String coin, String walletId, String walletPass,
+                                         Map<String, BigDecimal> recipients, String sequenceId,
+                                         Map<String, Object> optionalParameters) throws IOException;
 
     Optional<Map<String, Object>> getCurrentUserProfile() throws IOException;
 

--- a/bitgo-java-api/src/main/java/com/bitso/bitgo/v2/BitGoClient.java
+++ b/bitgo-java-api/src/main/java/com/bitso/bitgo/v2/BitGoClient.java
@@ -3,10 +3,8 @@ package com.bitso.bitgo.v2;
 import com.bitso.bitgo.v2.entity.SendCoinsResponse;
 import com.bitso.bitgo.v2.entity.Wallet;
 import com.bitso.bitgo.v2.entity.WalletTransferResponse;
-import org.json.JSONObject;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -47,6 +45,7 @@ public interface BitGoClient {
      * recipients                  A map with the recipients' addresses as keys and the corresponding
      *                                    amounts as values. Amounts are in satoshis
      * sequenceId                  A unique identifier for this transaction (optional).
+     *
      * Optional parameters are:
      * message                     Notes about the transaction (optional).
      * fee                         Fee (in satoshis), leave null for autodetect. Do not specify unless you are sure it is sufficient.
@@ -55,7 +54,7 @@ public interface BitGoClient {
      * enforceMinConfirmsForChange Defaults to false. When constructing a transaction, minConfirms will only be enforced for unspents not originating from the wallet
      * @return A SendCoinsResponse, or empty if there was a problem (although more likely in case of a problem it will throw).
      */
-    Optional<SendCoinsResponse> sendMany(JSONObject parameters) throws IOException;
+    Optional<SendCoinsResponse> sendMany(Map<String, Object> parameters) throws IOException;
 
     Optional<Map<String, Object>> getCurrentUserProfile() throws IOException;
 

--- a/bitgo-java-api/src/main/java/com/bitso/bitgo/v2/BitGoClient.java
+++ b/bitgo-java-api/src/main/java/com/bitso/bitgo/v2/BitGoClient.java
@@ -3,6 +3,7 @@ package com.bitso.bitgo.v2;
 import com.bitso.bitgo.v2.entity.SendCoinsResponse;
 import com.bitso.bitgo.v2.entity.Wallet;
 import com.bitso.bitgo.v2.entity.WalletTransferResponse;
+import org.json.JSONObject;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -39,26 +40,22 @@ public interface BitGoClient {
 
     /**
      * Invokes the sendmany method see https://www.bitgo.com/api/v2/?shell#send-transaction-to-many
-     *
-     * @param coin                        tbtc for test bitcoin, see full list at https://www.bitgo.com/api/v2/#coin-digital-currency-support
-     * @param walletId                    The ID of the source wallet.
-     * @param walletPass                  The wallet passphrase.
-     * @param recipients                  A map with the recipients' addresses as keys and the corresponding
+     * Required parameters are:
+     * coin                        tbtc for test bitcoin, see full list at https://www.bitgo.com/api/v2/#coin-digital-currency-support
+     * walletId                    The ID of the source wallet.
+     * walletPass                  The wallet passphrase.
+     * recipients                  A map with the recipients' addresses as keys and the corresponding
      *                                    amounts as values. Amounts are in satoshis
-     * @param sequenceId                  A unique identifier for this transaction (optional).
-     * @param message                     Notes about the transaction (optional).
-     * @param fee                         Fee (in satoshis), leave null for autodetect. Do not specify unless you are sure it is sufficient.
-     * @param feeTxConfirmTarget          Calculate fees per kilobyte, targeting transaction confirmation in this number of blocks. Default: 2, Minimum: 2, Maximum: 20
-     * @param minConfirms                 only choose unspent inputs with a certain number of confirmations. We recommend setting this to 1 and using enforceMinConfirmsForChange
-     * @param enforceMinConfirmsForChange Defaults to false. When constructing a transaction, minConfirms will only be enforced for unspents not originating from the wallet
+     * sequenceId                  A unique identifier for this transaction (optional).
+     * Optional parameters are:
+     * message                     Notes about the transaction (optional).
+     * fee                         Fee (in satoshis), leave null for autodetect. Do not specify unless you are sure it is sufficient.
+     * feeTxConfirmTarget          Calculate fees per kilobyte, targeting transaction confirmation in this number of blocks. Default: 2, Minimum: 2, Maximum: 20
+     * minConfirms                 only choose unspent inputs with a certain number of confirmations. We recommend setting this to 1 and using enforceMinConfirmsForChange
+     * enforceMinConfirmsForChange Defaults to false. When constructing a transaction, minConfirms will only be enforced for unspents not originating from the wallet
      * @return A SendCoinsResponse, or empty if there was a problem (although more likely in case of a problem it will throw).
      */
-    Optional<SendCoinsResponse> sendMany(String coin, String walletId, String walletPass,
-                                         Map<String, BigDecimal> recipients,
-                                         String sequenceId, String message,
-                                         BigDecimal fee, BigDecimal feeTxConfirmTarget,
-                                         int minConfirms, boolean enforceMinConfirmsForChange)
-            throws IOException;
+    Optional<SendCoinsResponse> sendMany(JSONObject parameters) throws IOException;
 
     Optional<Map<String, Object>> getCurrentUserProfile() throws IOException;
 

--- a/bitgo-java-api/src/main/java/com/bitso/bitgo/v2/BitGoClientImpl.java
+++ b/bitgo-java-api/src/main/java/com/bitso/bitgo/v2/BitGoClientImpl.java
@@ -109,7 +109,7 @@ public class BitGoClientImpl implements BitGoClient {
                                                 @NonNull Map<String, BigDecimal> recipients, @NonNull String sequenceId,
                                                 Map<String, Object> optionalParameters) throws IOException {
         // Validate all needed parameters
-        if (!coin.matches("^(btc|ltc|bch|tbtc|tltc|tbch)$")) {
+        if (coin.equals("")) {
             throw new IOException("Invalid currency");
         }
         if (walletId.equals("")) {

--- a/bitgo-java-api/src/main/java/com/bitso/bitgo/v2/BitGoClientImpl.java
+++ b/bitgo-java-api/src/main/java/com/bitso/bitgo/v2/BitGoClientImpl.java
@@ -110,19 +110,19 @@ public class BitGoClientImpl implements BitGoClient {
                                                 Map<String, Object> optionalParameters) throws IOException {
         // Validate all needed parameters
         if (coin.isBlank()) {
-            throw new IOException("Invalid currency");
+            throw new IllegalArgumentException("Invalid currency");
         }
         if (walletId.isBlank()) {
-            throw new IOException("WalletId can't be empty");
+            throw new IllegalArgumentException("WalletId can't be empty");
         }
         if (walletPass.isBlank()) {
-            throw new IOException("WalletPass can't be empty ");
+            throw new IllegalArgumentException("WalletPass can't be empty ");
         }
         if (sequenceId.isBlank()) {
-            throw new IOException("SequenceId can't be empty");
+            throw new IllegalArgumentException("SequenceId can't be empty");
         }
         if (recipients.size() == 0) {
-            throw new IOException("Transaction must have at least one address/amount tuple as destination");
+            throw new IllegalArgumentException("Transaction must have at least one address/amount tuple as destination");
         }
 
         String url = baseUrl + SEND_MANY_URL.replace("$COIN", coin).replace("$WALLET", walletId);
@@ -154,7 +154,7 @@ public class BitGoClientImpl implements BitGoClient {
                         if (optionalValue instanceof BigDecimal) {
                             data.put(optionalKey, ((BigDecimal) optionalValue).toBigInteger());
                         } else {
-                            throw new IOException("Fee should be a BigDecimal value");
+                            throw new IllegalArgumentException("Fee should be a BigDecimal value");
                         }
                     }
                 } else if (optionalKey.equals("feeTxConfirmTarget")) {
@@ -162,7 +162,7 @@ public class BitGoClientImpl implements BitGoClient {
                         if (optionalValue instanceof BigDecimal) {
                             data.put(optionalKey, optionalValue);
                         } else {
-                            throw new IOException("FeeTxConfirmTarget should be a BigDecimal value");
+                            throw new IllegalArgumentException("FeeTxConfirmTarget should be a BigDecimal value");
                         }
                     }
                 } else if (optionalKey.equals("minConfirms")) {
@@ -170,7 +170,7 @@ public class BitGoClientImpl implements BitGoClient {
                         if (optionalValue instanceof Integer && ((int) optionalValue > 0)) {
                             data.put(optionalKey, optionalValue);
                         } else {
-                            throw new IOException("MinConfirms should be an Integer value higher than 0");
+                            throw new IllegalArgumentException("MinConfirms should be an Integer value higher than 0");
                         }
                     }
                 } else if (optionalKey.equals("enforceMinConfirmsForChange")) {
@@ -178,7 +178,7 @@ public class BitGoClientImpl implements BitGoClient {
                         if (optionalValue instanceof Boolean) {
                             data.put(optionalKey, optionalValue);
                         } else {
-                            throw new IOException("EnforceMinConfirmsForChange should be a Boolean value");
+                            throw new IllegalArgumentException("EnforceMinConfirmsForChange should be a Boolean value");
                         }
                     }
                 } else if (optionalValue != null) {

--- a/bitgo-java-api/src/main/java/com/bitso/bitgo/v2/BitGoClientImpl.java
+++ b/bitgo-java-api/src/main/java/com/bitso/bitgo/v2/BitGoClientImpl.java
@@ -22,8 +22,6 @@ import java.util.Optional;
 import java.util.Scanner;
 import java.util.concurrent.TimeUnit;
 
-import org.json.JSONObject;
-
 /**
  * Implementation of the BitGo client.
  *
@@ -106,27 +104,28 @@ public class BitGoClientImpl implements BitGoClient {
     }
 
     @Override
-    public Optional<SendCoinsResponse> sendMany(JSONObject parameters) throws IOException {
+    public Optional<SendCoinsResponse> sendMany(Map<String, Object> parameters) throws IOException {
         // Get all needed parameters
-        String coin = parameters.getString("coin");
-        String walletId = parameters.getString("walletId");
-        String walletPass = parameters.getString("walletPass");
-        JSONObject targets = parameters.getJSONObject("recipients");
-        HashMap<String, BigDecimal> recipients = new HashMap<String, BigDecimal>(targets.length());
+        String coin = parameters.get("coin").toString();
+        String walletId = parameters.get("walletId").toString();
+        String walletPass = parameters.get("walletPass").toString();
+        Map<String, Object> targets = (Map<String, Object>)parameters.get("recipients");
+        HashMap<String, BigDecimal> recipients = new HashMap<String, BigDecimal>(targets.size());
         for (String address : targets.keySet()) {
-            recipients.put(address, targets.getBigDecimal(address));
+            recipients.put(address, new BigDecimal(targets.get(address).toString()));
         }
-        String sequenceId = parameters.getString("sequenceId");
-        // Check for optional parameters or default them
-        String message = parameters.has("message") ? parameters.getString("message") : "";
-        BigDecimal fee = parameters.has("fee") ? parameters.getBigDecimal("fee") : BigDecimal.ZERO;
-        BigDecimal feeTxConfirmTarget = parameters.has("feeTxConfirmTarget") ?
-                parameters.getBigDecimal("feeTxConfirmTarget") : BigDecimal.ZERO;
-        int minConfirms = parameters.has("minConfirms") ? parameters.getInt("minConfirms") : 0;
-        boolean enforceMinConfirmsForChange = parameters.has("enforceMinConfirmsForChange") ?
-                parameters.getBoolean("enforceMinConfirmsForChange") : false;
-        String url = baseUrl + SEND_MANY_URL.replace("$COIN", coin).replace("$WALLET", walletId);
+        String sequenceId = parameters.get("sequenceId").toString();
 
+        // Check for optional parameters or default them to null
+        String message = parameters.containsKey("message") ? parameters.get("message").toString() : null;
+        BigDecimal fee = parameters.containsKey("fee") ? new BigDecimal(parameters.get("fee").toString()) : null;
+        BigDecimal feeTxConfirmTarget = parameters.containsKey("feeTxConfirmTarget") ?
+                new BigDecimal(parameters.get("feeTxConfirmTarget").toString()) : null;
+        int minConfirms = parameters.containsKey("minConfirms") ? Integer.parseInt(parameters.get("minConfirms").toString()) : null;
+        boolean enforceMinConfirmsForChange = parameters.containsKey("enforceMinConfirmsForChange") ?
+                Boolean.valueOf(parameters.get("enforceMinConfirmsForChange").toString()) : null;
+
+        String url = baseUrl + SEND_MANY_URL.replace("$COIN", coin).replace("$WALLET", walletId);
         final List<Map<String, Object>> addr = new ArrayList<>(recipients.size());
         for (Map.Entry<String, BigDecimal> e : recipients.entrySet()) {
             Map<String, Object> a = new HashMap<>(2);

--- a/bitgo-java-api/src/main/java/com/bitso/bitgo/v2/BitGoClientImpl.java
+++ b/bitgo-java-api/src/main/java/com/bitso/bitgo/v2/BitGoClientImpl.java
@@ -109,16 +109,16 @@ public class BitGoClientImpl implements BitGoClient {
                                                 @NonNull Map<String, BigDecimal> recipients, @NonNull String sequenceId,
                                                 Map<String, Object> optionalParameters) throws IOException {
         // Validate all needed parameters
-        if (coin.equals("")) {
+        if (coin.isBlank()) {
             throw new IOException("Invalid currency");
         }
-        if (walletId.equals("")) {
+        if (walletId.isBlank()) {
             throw new IOException("WalletId can't be empty");
         }
-        if (walletPass.equals("")) {
+        if (walletPass.isBlank()) {
             throw new IOException("WalletPass can't be empty ");
         }
-        if (sequenceId.equals("")) {
+        if (sequenceId.isBlank()) {
             throw new IOException("SequenceId can't be empty");
         }
         if (recipients.size() == 0) {
@@ -147,15 +147,11 @@ public class BitGoClientImpl implements BitGoClient {
                 optionalValue = currentParameter.getValue();
                 if (optionalKey.equals("message")) {
                     if (optionalValue != null) {
-                        if (optionalValue.getClass().getName().equals(String.class.getName())) {
-                            data.put(optionalKey, optionalValue.toString());
-                        } else {
-                            throw new IOException("Message should be a String value");
-                        }
+                        data.put(optionalKey, optionalValue.toString());
                     }
                 } else if (optionalKey.equals("fee")) {
                     if (optionalValue != null) {
-                        if (optionalValue.getClass().getName().equals(BigDecimal.class.getName())) {
+                        if (optionalValue instanceof BigDecimal) {
                             data.put(optionalKey, ((BigDecimal) optionalValue).toBigInteger());
                         } else {
                             throw new IOException("Fee should be a BigDecimal value");
@@ -163,7 +159,7 @@ public class BitGoClientImpl implements BitGoClient {
                     }
                 } else if (optionalKey.equals("feeTxConfirmTarget")) {
                     if (optionalValue != null) {
-                        if (optionalValue.getClass().getName().equals(BigDecimal.class.getName())) {
+                        if (optionalValue instanceof BigDecimal) {
                             data.put(optionalKey, optionalValue);
                         } else {
                             throw new IOException("FeeTxConfirmTarget should be a BigDecimal value");
@@ -171,7 +167,7 @@ public class BitGoClientImpl implements BitGoClient {
                     }
                 } else if (optionalKey.equals("minConfirms")) {
                     if (optionalValue != null) {
-                        if (optionalValue.getClass().getName().equals(Integer.class.getName()) && ((int) optionalValue > 0)) {
+                        if (optionalValue instanceof Integer && ((int) optionalValue > 0)) {
                             data.put(optionalKey, optionalValue);
                         } else {
                             throw new IOException("MinConfirms should be an Integer value higher than 0");
@@ -179,17 +175,15 @@ public class BitGoClientImpl implements BitGoClient {
                     }
                 } else if (optionalKey.equals("enforceMinConfirmsForChange")) {
                     if (optionalValue != null) {
-                        if (optionalValue.getClass().getName().equals(Boolean.class.getName())) {
+                        if (optionalValue instanceof Boolean) {
                             data.put(optionalKey, optionalValue);
                         } else {
                             throw new IOException("EnforceMinConfirmsForChange should be a Boolean value");
                         }
                     }
-                } else {
+                } else if (optionalValue != null) {
                     // Unknown parameter for validation, if not null allow it to pass to the transaction request
-                    if (optionalValue != null) {
-                        data.put(optionalKey, optionalValue);
-                    }
+                    data.put(optionalKey, optionalValue);
                 }
             }
         }

--- a/bitgo-java-api/src/test/java/com/bitso/bitgo/util/TestClientV2.java
+++ b/bitgo-java-api/src/test/java/com/bitso/bitgo/util/TestClientV2.java
@@ -6,6 +6,7 @@ import com.bitso.bitgo.v2.entity.SendCoinsResponse;
 import com.bitso.bitgo.v2.entity.Wallet;
 import com.bitso.bitgo.v2.entity.WalletTransferResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -41,7 +42,7 @@ public class TestClientV2 {
     @Test
     @Ignore
     public void testSendMany() throws IOException {
-
+        JSONObject parameters = new JSONObject();
         int unlockResult = client.unlock("0000000", TimeUnit.HOURS.toSeconds(1));
         System.out.println(unlockResult);
         assertTrue(unlockResult != 400 && unlockResult != 401);
@@ -52,9 +53,15 @@ public class TestClientV2 {
             targets.put(TLTC_TEST_FAUCET_ADDRESS, amount);
             amount = amount.add(initAmount);
         }
-//        targets.put("[ADDRESS2]", new BigDecimal("0.001"));
-        Optional<SendCoinsResponse> resp = client.sendMany(COIN, WALLET_ID, WALLET_PASSPHRASE, targets, null,
-                "test", null, null, 1, true);
+        parameters.put("coin", COIN);
+        parameters.put("walletId", WALLET_ID);
+        parameters.put("walletPass", WALLET_PASSPHRASE);
+        parameters.put("recipients", targets);
+        parameters.put("message", "test");
+        parameters.put("minConfirms", 1);
+        parameters.put("enforceMinConfirmsForChange", true);
+        parameters.put("sequenceId", "btc33");
+        Optional<SendCoinsResponse> resp = client.sendMany(parameters);
         Assert.assertTrue(resp.isPresent());
         Assert.assertNotNull(resp.get().getTx());
 
@@ -90,7 +97,7 @@ public class TestClientV2 {
 //        for (int i = 0; i < 30; i++) {
 //            resp.getTransfers().remove(0);
 //        }
-        System.out.println("resp json = "+ SerializationUtil.mapper.writeValueAsString(resp));
+        System.out.println("resp json = " + SerializationUtil.mapper.writeValueAsString(resp));
 
 
     }

--- a/bitgo-java-api/src/test/java/com/bitso/bitgo/util/TestClientV2.java
+++ b/bitgo-java-api/src/test/java/com/bitso/bitgo/util/TestClientV2.java
@@ -55,7 +55,7 @@ public class TestClientV2 {
         parameters.put("message", "test");
         parameters.put("minConfirms", 1);
         parameters.put("enforceMinConfirmsForChange", true);
-        String sequenceId = "btc35"; //Set it up for transaction to work
+        String sequenceId = ""; //Set it up for transaction to work
         Optional<SendCoinsResponse> resp = client.sendMany(COIN, WALLET_ID, WALLET_PASSPHRASE, targets, sequenceId, parameters);
         Assert.assertTrue(resp.isPresent());
         Assert.assertNotNull(resp.get().getTx());

--- a/bitgo-java-api/src/test/java/com/bitso/bitgo/util/TestClientV2.java
+++ b/bitgo-java-api/src/test/java/com/bitso/bitgo/util/TestClientV2.java
@@ -60,7 +60,7 @@ public class TestClientV2 {
         parameters.put("message", "test");
         parameters.put("minConfirms", 1);
         parameters.put("enforceMinConfirmsForChange", true);
-        parameters.put("sequenceId", "btc33");
+        parameters.put("sequenceId", ""); //Set it up for transaction to work
         Optional<SendCoinsResponse> resp = client.sendMany(parameters);
         Assert.assertTrue(resp.isPresent());
         Assert.assertNotNull(resp.get().getTx());

--- a/bitgo-java-api/src/test/java/com/bitso/bitgo/util/TestClientV2.java
+++ b/bitgo-java-api/src/test/java/com/bitso/bitgo/util/TestClientV2.java
@@ -6,7 +6,7 @@ import com.bitso.bitgo.v2.entity.SendCoinsResponse;
 import com.bitso.bitgo.v2.entity.Wallet;
 import com.bitso.bitgo.v2.entity.WalletTransferResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.json.JSONObject;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -42,7 +42,7 @@ public class TestClientV2 {
     @Test
     @Ignore
     public void testSendMany() throws IOException {
-        JSONObject parameters = new JSONObject();
+        Map<String, Object> parameters = new HashMap<String, Object>();
         int unlockResult = client.unlock("0000000", TimeUnit.HOURS.toSeconds(1));
         System.out.println(unlockResult);
         assertTrue(unlockResult != 400 && unlockResult != 401);
@@ -65,6 +65,37 @@ public class TestClientV2 {
         Assert.assertTrue(resp.isPresent());
         Assert.assertNotNull(resp.get().getTx());
 
+    }
+
+    @Test
+    @Ignore
+    public void testSendManyFail() throws IOException {
+        Map<String, Object> parameters = new HashMap<String, Object>();
+        int unlockResult = client.unlock("0000000", TimeUnit.HOURS.toSeconds(1));
+        System.out.println(unlockResult);
+        assertTrue(unlockResult != 400 && unlockResult != 401);
+        Map<String, BigDecimal> targets = new HashMap<>();
+        BigDecimal initAmount = new BigDecimal("0.001").movePointRight(8);
+        BigDecimal amount = initAmount;
+        targets.put(TLTC_TEST_FAUCET_ADDRESS, amount);
+        // avoid coin required parameter to test error handling
+        parameters.put("coin", "");
+        parameters.put("walletId", WALLET_ID);
+        parameters.put("walletPass", WALLET_PASSPHRASE);
+        parameters.put("recipients", targets);
+        parameters.put("message", "test");
+        parameters.put("minConfirms", 1);
+        parameters.put("enforceMinConfirmsForChange", true);
+        parameters.put("sequenceId", "btc34"); //Set it up for transaction to work
+        Optional<SendCoinsResponse> resp = client.sendMany(parameters);
+        // Coin is part of the URL of api, should not find the required page (also walletId is part of the URL)
+        Assert.assertEquals(404, resp.get().getResponseCode());
+        // Restart test swapping the wrong variable
+        parameters.put("coin", COIN);
+        parameters.put("sequenceId", "");
+        resp = client.sendMany(parameters);
+        Assert.assertEquals(400, resp.get().getResponseCode());
+        Assert.assertThat(resp.get().getError(), CoreMatchers.containsString("invalid sequence id"));
     }
 
     @Test


### PR DESCRIPTION
Changed the whole method to receive a JSONObject, I replaced it but I kept thinking if maybe could keep both forms, one with explicit params and one with the json and add an internal private sendMany to keep support for both, but I don't know if this is excesive? What you guys think?